### PR TITLE
fix: Stability improvements for Lab 4 Front Door (Fixes #4)

### DIFF
--- a/lab4/Readme.md
+++ b/lab4/Readme.md
@@ -18,7 +18,23 @@ This lab demonstrates Azure Front Door by deploying a simple Container App and A
     If you click on the "Deploy" stage, it will open up and you can follow the progres of the deployemnt. If something fails, look at the error message and figure out if there is something in the setup (readme at the root of to reposiroty) that is wrong.
 
 4. Once everything is complete, login to Azure Portal and investigate at the created resource group
-5. Find the URL of the FrontDoor. Paste it into a browser and see if works. This might take some time (it is installed all over the world by microsoft). 
+5. Find the URL of the FrontDoor endpoint (should look like `https://afd-<random>.z01.azurefd.net`).
+
+### Verification & Troubleshooting
+1.  **Check Origin Health**:
+    *   In the Azure Portal, go to your **Front Door and CDN profiles** resource.
+    *   Click **Origin groups** -> **MyOriginGroup**.
+    *   Check the "Percentage" or health status. It should be 100%. If it is 0%, Front Door cannot reach your Container App.
+2.  **Verify HTTPS**:
+    *   Copy the Front Door URL.
+    *   Open it in your browser. It should load the "Massively" or "Hacked" website securely (Lock icon).
+    *   Try accessing with `http://...`. It should automatically redirect to `https://...`.
+3.  **Troubleshooting Connection Issues**:
+    *   **503 Service Unavailable**: Usually means the Origin (Container App) is unhealthy or unreachable.
+        *   *Fix*: Check the Origin Group health probes. Ensure the Container App is running and responding to HTTPS requests.
+    *   **502 Bad Gateway**: Front Door reached the app but got an invalid response.
+        *   *Fix*: Ensure the `hostHeader` matches the Container App's FQDN (this is handled in the Bicep).
+    *   **Certificate Errors**: Ensure you are accessing the specific Front Door URL, not the generic one if you haven't set up custom domains.
 
 ### Accessing the Application
 ### Acceptance Criteria

--- a/lab4/lab.bicep
+++ b/lab4/lab.bicep
@@ -88,7 +88,7 @@ resource frontDoorOriginGroup 'Microsoft.Cdn/profiles/originGroups@2021-06-01' =
     healthProbeSettings: {
       probePath: '/'
       probeRequestType: 'HEAD'
-      probeProtocol: 'Http'
+      probeProtocol: 'Https' // Changed from Http to Https to avoid 301 Redirects from ACA
       probeIntervalInSeconds: 120
     }
   }
@@ -101,6 +101,7 @@ resource frontDoorOrigin 'Microsoft.Cdn/profiles/originGroups/origins@2021-06-01
   properties: {
     hostName: containerApp.properties.configuration.ingress.fqdn
     httpPort: 80
+    httpsPort: 443 // Explicitly defined to ensure HttpsOnly forwarding works
     originHostHeader: containerApp.properties.configuration.ingress.fqdn
     priority: 1
     weight: 1000


### PR DESCRIPTION
This PR fixes connectivity flakiness in Lab 4 by ensuring Front Door uses HTTPS for health probes and backend connections, avoiding potential 301 redirect loops. It also adds a troubleshooting section to the Lab 4 README.